### PR TITLE
Potential fix for code scanning alert no. 5: Use of insecure SSL/TLS version

### DIFF
--- a/EC2/terraform/modules/lambda/python/urllib3/util/ssl_.py
+++ b/EC2/terraform/modules/lambda/python/urllib3/util/ssl_.py
@@ -498,6 +498,12 @@ def _ssl_wrap_socket_impl(sock, ssl_context, tls_in_tls, server_hostname=None):
         SSLTransport._validate_ssl_context_for_tls_in_tls(ssl_context)
         return SSLTransport(sock, ssl_context, server_hostname)
 
+    # Ensure the SSLContext enforces a secure protocol version
+    if hasattr(ssl_context, "minimum_version"):
+        ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+    else:
+        ssl_context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+
     if server_hostname:
         return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/Twodragon0/AWS/security/code-scanning/5](https://github.com/Twodragon0/AWS/security/code-scanning/5)

To address the issue, we need to ensure that the `SSLContext` object enforces a secure protocol version (TLSv1.2 or higher). This can be achieved by explicitly setting the `minimum_version` attribute of the `SSLContext` object to `ssl.TLSVersion.TLSv1_2`. This approach is supported in Python 3.7 and later. For compatibility with earlier versions of Python, we can use the `options` attribute to disable insecure protocols (e.g., `ssl.OP_NO_TLSv1` and `ssl.OP_NO_TLSv1_1`).

The fix involves modifying the code where the `SSLContext` is created or configured to ensure that only secure protocols are allowed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
