### PR TITLE
Potential fix for code scanning alert no. 102: Clear-text logging of sensitive information

### DIFF
--- a/Bedrock/node_modules/@cdklabs/generative-ai-cdk-constructs/lambda/aws-text-to-sql/query_executor/db_helper.py
+++ b/Bedrock/node_modules/@cdklabs/generative-ai-cdk-constructs/lambda/aws-text-to-sql/query_executor/db_helper.py
@@ -57,12 +57,12 @@ def get_secret():
         SecretId=secret_arn
     )
     
-    print(f"get_secret_value_response :: {get_secret_value_response}")
+    logger.info("Successfully retrieved secret value from Secrets Manager.")
 
     if 'SecretString' in get_secret_value_response:
         secret = get_secret_value_response['SecretString']
     else:
         logger.error("Error: Unable to retrieve texttosqldbsecret value")
     
-    logger.info(f'secret :: {secret}')  
+    logger.info("Secret successfully parsed and loaded.")  
     return json.loads(secret)


### PR DESCRIPTION
Potential fix for [https://github.com/Twodragon0/AWS/security/code-scanning/102](https://github.com/Twodragon0/AWS/security/code-scanning/102)

To fix the issue, we need to remove or sanitize the logging of sensitive data. Specifically, the line `print(f"get_secret_value_response :: {get_secret_value_response}")` should be replaced with a safer alternative. Instead of logging the entire response, we can log only non-sensitive metadata (e.g., the secret's ARN or a success message) to confirm the operation's success without exposing sensitive details.

Additionally, the line `logger.info(f'secret :: {secret}')` on line 67 also logs sensitive data and should be sanitized or removed. Logging the secret itself is unnecessary and poses a similar risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
